### PR TITLE
[Fix] Fixed housing highlights and gyms/tributes not autobuying

### DIFF
--- a/autotrimp.js
+++ b/autotrimp.js
@@ -247,7 +247,7 @@ if (autoTSettings.autobuildings.enabled == 1) {
 
 //Buy tributes
 if (autoTSettings.autogymbutes.enabled == 1 || autoTSettings.autogymbutes.enabled == 3) {
-	if (getBuildingItemPrice(game.buildings.Tribute, "food", false) <= game.resources.food.owned && game.buildings.Tribute.locked == 0) {
+	if (getBuildingItemPrice(game.buildings.Tribute, "food", false, game.global.buyAmt) <= game.resources.food.owned && game.buildings.Tribute.locked == 0) {
 		buyBuilding('Tribute');
 		tooltip("hide");
 		message("Bought us a tribute. The gems must flow!", "Loot", "*eye2", "exotic")
@@ -300,7 +300,7 @@ if (autoTSettings.automapbmax.enabled == 1 && game.global.mapsActive && !game.gl
 
 //Buy gyms
 if (autoTSettings.autogymbutes.enabled == 1 || autoTSettings.autogymbutes.enabled == 2) {
-	if (getBuildingItemPrice(game.buildings.Gym, "wood", false) <= game.resources.wood.owned && game.buildings.Gym.locked == 0) {
+	if (getBuildingItemPrice(game.buildings.Gym, "wood", false, game.global.buyAmt) <= game.resources.wood.owned && game.buildings.Gym.locked == 0) {
 		buyBuilding('Gym');
 		tooltip("hide");
 		message("Bought us a gym. Open 24/7.", "Loot", "*eye2", "exotic")

--- a/autotrimp.js
+++ b/autotrimp.js
@@ -133,7 +133,10 @@ function updateHousingHighlighting() {
 		for (ghouse in ghousing) {
 			var gbuilding = game.buildings[ghousing[ghouse]];
 			var gcost = 0;
-			gcost += getBuildingItemPrice(gbuilding, "gems");
+			gcost += getBuildingItemPrice(gbuilding, "gems", 0, game.global.buyAmt);
+			if (gcost === Infinity) {
+				return;
+			}
 			var gratio = gcost / gbuilding.increase.by;
 			gobj[ghousing[ghouse]] = gratio;
 			if (document.getElementById(ghousing[ghouse]).style.border = "1px solid #00CC00") {


### PR DESCRIPTION
fixed function `updateHousingHighlighting` to not return `NaN` in multiple places
